### PR TITLE
Lease keys in etcd

### DIFF
--- a/cmd/rate/main.go
+++ b/cmd/rate/main.go
@@ -75,7 +75,7 @@ func main() {
 		cli, err := clientv3.New(clientv3.Config{Endpoints: strings.Split(*addrs, ",")})
 		checkError(err)
 
-		acquirer = persistent.NewSemaphore(cli.KV, *rpm)
+		acquirer = persistent.NewSemaphore(cli.KV, *rpm, persistent.WithLease(cli.Lease))
 	}
 
 	var (

--- a/pkg/persistent/options.go
+++ b/pkg/persistent/options.go
@@ -1,5 +1,7 @@
 package persistent
 
+import "go.etcd.io/etcd/clientv3"
+
 // Option is a functional option for *Semaphore
 type Option func(*Semaphore)
 
@@ -18,5 +20,12 @@ func (o Options) Apply(s *Semaphore) {
 func WithKeyer(keyer Keyer) Option {
 	return func(s *Semaphore) {
 		s.keyer = keyer
+	}
+}
+
+// WithLease sets an etcd lease on the Semaphore
+func WithLease(lease clientv3.Lease) Option {
+	return func(s *Semaphore) {
+		s.lease = lease
 	}
 }

--- a/pkg/persistent/persistent_test.go
+++ b/pkg/persistent/persistent_test.go
@@ -15,6 +15,22 @@ import (
 
 var addresses = os.Getenv("ETCD_ADDRESSES")
 
+func attemptIs(t *testing.T, sem *Semaphore, ctxt context.Context, path string, successful bool) {
+	t.Helper()
+
+	acquired, err := sem.Acquire(ctxt, "/foo")
+	assert.Nil(t, err)
+	assert.Equal(t, successful, acquired)
+}
+
+func attemptIsSuccessful(t *testing.T, sem *Semaphore, ctxt context.Context, path string) {
+	attemptIs(t, sem, ctxt, path, true)
+}
+
+func attemptIsUnsuccessful(t *testing.T, sem *Semaphore, ctxt context.Context, path string) {
+	attemptIs(t, sem, ctxt, path, false)
+}
+
 func Test_Acquire(t *testing.T) {
 	cli, err := clientv3.New(clientv3.Config{Endpoints: strings.Split(addresses, ",")})
 	if err != nil {
@@ -22,16 +38,11 @@ func Test_Acquire(t *testing.T) {
 	}
 
 	var (
-		keyer   = staticKeyer(time.Now().Format("2006-01-02T15:04:05.9999999"))
-		sem     = NewSemaphore(clientv3.NewKV(cli), 2, WithKeyer(keyer))
-		ctxt    = context.Background()
-		attempt = func(successful bool) {
-			acquired, err := sem.Acquire(ctxt, "/foo")
-			assert.Nil(t, err)
-			assert.Equal(t, successful, acquired)
-		}
-		successfulAttempt = func() { attempt(true) }
-		failedAttempt     = func() { attempt(false) }
+		keyer             = staticKeyer(time.Now().Format("2006-01-02T15:04:05.9999999"))
+		sem               = NewSemaphore(clientv3.NewKV(cli), 2, WithKeyer(keyer))
+		ctxt              = context.Background()
+		successfulAttempt = func() { attemptIsSuccessful(t, sem, ctxt, "/foo") }
+		failedAttempt     = func() { attemptIsUnsuccessful(t, sem, ctxt, "/foo") }
 	)
 
 	successfulAttempt()
@@ -41,6 +52,35 @@ func Test_Acquire(t *testing.T) {
 
 	// we move forward in time
 	WithKeyer(staticKeyer(time.Now().Format("2006-01-02T15:04:05.9999999")))(sem)
+
+	// two more successful attempts
+	successfulAttempt()
+	successfulAttempt()
+	// third attempt should return false as the limit is 2
+	failedAttempt()
+}
+
+func Test_Acquire_Expiration(t *testing.T) {
+	cli, err := clientv3.New(clientv3.Config{Endpoints: strings.Split(addresses, ",")})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var (
+		keyer             = staticKeyer("baz")
+		sem               = NewSemaphore(clientv3.NewKV(cli), 2, WithKeyer(keyer))
+		ctxt              = context.Background()
+		ttl               = 2 * time.Second
+		successfulAttempt = func() { attemptIsSuccessful(t, sem, ctxt, "/foo") }
+		failedAttempt     = func() { attemptIsUnsuccessful(t, sem, ctxt, "/foo") }
+	)
+
+	successfulAttempt()
+	successfulAttempt()
+	// third attempt should return false as the limit is 2
+	failedAttempt()
+
+	time.Sleep(ttl)
 
 	// two more successful attempts
 	successfulAttempt()

--- a/pkg/persistent/persistent_test.go
+++ b/pkg/persistent/persistent_test.go
@@ -68,9 +68,9 @@ func Test_Acquire_Expiration(t *testing.T) {
 
 	var (
 		keyer             = staticKeyer("baz")
-		sem               = NewSemaphore(clientv3.NewKV(cli), 2, WithKeyer(keyer))
+		opts              = Options{WithKeyer(keyer), WithLease(clientv3.NewLease(cli))}
+		sem               = NewSemaphore(clientv3.NewKV(cli), 2, opts...)
 		ctxt              = context.Background()
-		ttl               = 2 * time.Second
 		successfulAttempt = func() { attemptIsSuccessful(t, sem, ctxt, "/foo") }
 		failedAttempt     = func() { attemptIsUnsuccessful(t, sem, ctxt, "/foo") }
 	)
@@ -80,7 +80,7 @@ func Test_Acquire_Expiration(t *testing.T) {
 	// third attempt should return false as the limit is 2
 	failedAttempt()
 
-	time.Sleep(ttl)
+	time.Sleep(6 * time.Second)
 
 	// two more successful attempts
 	successfulAttempt()

--- a/pkg/persistent/support_test.go
+++ b/pkg/persistent/support_test.go
@@ -10,5 +10,5 @@ var _ Keyer = staticKeyer("")
 type staticKeyer string
 
 func (s staticKeyer) Key(key string) (string, time.Duration) {
-	return fmt.Sprintf("%s/%s", s, key), time.Duration(0)
+	return fmt.Sprintf("%s/%s", s, key), time.Duration(5)
 }

--- a/pkg/persistent/support_test.go
+++ b/pkg/persistent/support_test.go
@@ -1,9 +1,14 @@
 package persistent
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
+
+var _ Keyer = staticKeyer("")
 
 type staticKeyer string
 
-func (s staticKeyer) Key(key string) string {
-	return fmt.Sprintf("%s/%s", s, key)
+func (s staticKeyer) Key(key string) (string, time.Duration) {
+	return fmt.Sprintf("%s/%s", s, key), time.Duration(0)
 }


### PR DESCRIPTION
This PR integrates TTLs on keys into the etcd key space.

We don't want to let keys build up over time. This will eventually get unwieldy. So instead, we will lease each key up to each interval. Then let etcd discard them.

TODO
- [x] Add failing test which expects a key to be reusable after an ellapsed time
- [x] Use etcd lease with a TTL to evict keys after a certain duration
- [x] wire `clientv3.Lease` into main.go